### PR TITLE
Add version numbering to make component usable again

### DIFF
--- a/custom_components/soundtouch/manifest.json
+++ b/custom_components/soundtouch/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/soundtouch",
   "requirements": ["libsoundtouch==0.8"],
   "after_dependencies": ["zeroconf"],
-  "codeowners": []
+  "codeowners": [],
+  "version": "1.1.0"
 }


### PR DESCRIPTION
Fixes https://github.com/geertsmichael/soundtouch/issues/1

Required since HA 2021.6, otherwise component does not work anymore. 